### PR TITLE
Use Docker Compose Watch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,13 @@ services:
       - database
     command:
       bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./runtimes/eoapi/stac/eoapi
+          target: /opt/bitnami/python/lib/python3.11/site-packages/eoapi
+        - action: rebuild
+          path: ./runtimes/eoapi/stac/pyproject.toml
     volumes:
       - ./dockerfiles/scripts:/tmp/scripts
 
@@ -84,6 +91,13 @@ services:
       - database
     command:
       bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./runtimes/eoapi/raster/eoapi
+          target: /opt/bitnami/python/lib/python3.11/site-packages/eoapi
+        - action: rebuild
+          path: ./runtimes/eoapi/raster/pyproject.toml
     volumes:
       - ./dockerfiles/scripts:/tmp/scripts
 
@@ -108,6 +122,13 @@ services:
       - EOAPI_VECTOR_DEBUG=TRUE
     command:
       bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
+    develop:
+      watch:
+        - action: sync+restart
+          path: ./runtimes/eoapi/vector/eoapi
+          target: /opt/bitnami/python/lib/python3.11/site-packages/eoapi
+        - action: rebuild
+          path: ./runtimes/eoapi/vector/pyproject.toml
     depends_on:
       - database
     volumes:


### PR DESCRIPTION
## What I am changing
<!-- What were the high-level goals of the change? -->
In this PR, we enable [Docker Compose Watch](https://docs.docker.com/compose/file-watch/).  From the docs:

> The `watch` attribute automatically updates and previews your running Compose services as you edit and save your code. For many projects, this enables a hands-off development workflow once Compose is running, as services automatically update themselves when you save your work.

## How I did it
<!-- How did you go about achieving these goals? Any considerations made along the way? -->
- Add a watch config to each service. It will reload the project when the codebase changes and rebuild the project when the `pyproject.toml` changes (ie possibly requiring a reinstall of dependencies)

> [!NOTE]
> Unfortunately, this does _not_ restart services when environment variables are changed in the `docker-compose.yml` file. I am unsure how to do that with docker compose watch.

## How you can test it
<!-- How might a reviewer test your changes to verify that they work as expected? -->
- ensure your docker compose version is `>=2.22.0`: `docker compose version`
- start: `docker compose up`
- enter watch mode: press <kbd>w</kbd>
- save file in a service, note refresh in docker compose logs

## Related Issues
<!-- Reference any issues that inspired this PR. Use a keyword to auto-close any issues when this PR is merged (eg "closes #1") -->
-
