### PR TITLE
Support loading env vars from common env or service-level envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+*.env
 .venv
 env/
 venv/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3'
+version: "3"
 
 services:
-
   # change to official image when available https://github.com/radiantearth/stac-browser/pull/386
   stac-browser:
     build:
@@ -9,6 +8,11 @@ services:
       dockerfile: Dockerfile.browser
     ports:
       - "${MY_DOCKER_IP:-127.0.0.1}:8085:8085"
+    env_file:
+      - path: .env
+        required: false
+      - path: .stac-browser.env
+        required: false
     depends_on:
       - stac
       - raster
@@ -38,10 +42,14 @@ services:
       # PgSTAC extensions
       # - EOAPI_STAC_EXTENSIONS=["filter", "query", "sort", "fields", "pagination", "titiler", "transaction"]  # defaults
       # - EOAPI_STAC_CORS_METHODS='GET,POST,PUT,OPTIONS'
+    env_file:
+      - path: .env
+        required: false
+      - path: .stac.env
+        required: false
     depends_on:
       - database
-    command:
-      bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
+    command: bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
     develop:
       watch:
         - action: sync+restart
@@ -87,10 +95,14 @@ services:
       - MOSAIC_CONCURRENCY=1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    env_file:
+      - path: .env
+        required: false
+      - path: .raster.env
+        required: false
     depends_on:
       - database
-    command:
-      bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
+    command: bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
     develop:
       watch:
         - action: sync+restart
@@ -120,8 +132,12 @@ services:
       - DB_MIN_CONN_SIZE=1
       - DB_MAX_CONN_SIZE=10
       - EOAPI_VECTOR_DEBUG=TRUE
-    command:
-      bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
+    env_file:
+      - path: .env
+        required: false
+      - path: .vector.env
+        required: false
+    command: bash -c "bash /tmp/scripts/wait-for-it.sh -t 120 -h database -p 5432 && /start.sh"
     develop:
       watch:
         - action: sync+restart


### PR DESCRIPTION
## What I'm changing

This PR configures the docker-compose services to load environment variables from both a common `.env` file or a per-service file (e.g. `.raster.env`).

This enables both broad and fine-grained customization of the services (e.g. add `UVICORN_LOG_LEVEL=debug` to _all_ services via `.env` or to just one via `.{service}.env`.

## How I did it

We're adding multiple optional environment files, making this an entirely optional feature. As [per the docs](https://docs.docker.com/compose/environment-variables/set-environment-variables/#additional-information-1), the service-level env files will take precedence over a common env file.

I also committed changes made by Prettier when formatting the YAML on save.