### PR TITLE
Run Python in non-buffered mode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     ports:
       - "${MY_DOCKER_IP:-127.0.0.1}:8081:8081"
     environment:
+      - PYTHONUNBUFFERED=1
       # Application
       - HOST=0.0.0.0
       - PORT=8081
@@ -62,6 +63,7 @@ services:
     ports:
       - "${MY_DOCKER_IP:-127.0.0.1}:8082:8082"
     environment:
+      - PYTHONUNBUFFERED=1
       # Application
       - HOST=0.0.0.0
       - PORT=8082
@@ -108,6 +110,7 @@ services:
     ports:
       - "${MY_DOCKER_IP:-127.0.0.1}:8083:8083"
     environment:
+      - PYTHONUNBUFFERED=1
       # Application
       - HOST=0.0.0.0
       - PORT=8083


### PR DESCRIPTION
## What I'm changing

I've been noticing that there are times when my log statements or print statements are not visible in a python-based docker compose service's output until I close/restart the service.  This is because Python buffers its stdout by default.

## How I did it

Run services with `PYTHONBUFFERED=1` env var, which is akin to `python -u ...`.  As described in [the docs](https://docs.python.org/3/using/cmdline.html#cmdoption-u):

> Force the stdout and stderr streams to be unbuffered. This option has no effect on the stdin stream.

With this enabled, logs and print statements are made immediately available in the docker compose output.