### PR TITLE
Add logging to apps, reorg imports

### DIFF
--- a/runtimes/eoapi/raster/eoapi/raster/app.py
+++ b/runtimes/eoapi/raster/eoapi/raster/app.py
@@ -37,7 +37,8 @@ from titiler.pgstac.factory import (
 )
 from titiler.pgstac.reader import PgSTACReader
 
-from . import __version__ as eoapi_raster_version, auth, config, logs
+from . import __version__ as eoapi_raster_version
+from . import config, logs
 
 settings = config.ApiSettings()
 

--- a/runtimes/eoapi/raster/eoapi/raster/app.py
+++ b/runtimes/eoapi/raster/eoapi/raster/app.py
@@ -7,8 +7,6 @@ from typing import Dict
 
 import jinja2
 import pystac
-from eoapi.raster import __version__ as eoapi_raster_version
-from eoapi.raster.config import ApiSettings
 from fastapi import Depends, FastAPI, Query
 from psycopg import OperationalError
 from psycopg.rows import dict_row
@@ -39,12 +37,32 @@ from titiler.pgstac.factory import (
 )
 from titiler.pgstac.reader import PgSTACReader
 
-logging.getLogger("botocore.credentials").disabled = True
-logging.getLogger("botocore.utils").disabled = True
-logging.getLogger("rio-tiler").setLevel(logging.ERROR)
+from . import __version__ as eoapi_raster_version, auth, config, logs
 
-settings = ApiSettings()
+settings = config.ApiSettings()
 
+# Logs
+logs.init_logging(
+    debug=settings.debug,
+    loggers={
+        "botocore.credentials": {
+            "level": "CRITICAL",
+            "propagate": False,
+        },
+        "botocore.utils": {
+            "level": "CRITICAL",
+            "propagate": False,
+        },
+        "rio-tiler": {
+            "level": "ERROR",
+            "propagate": False,
+        },
+    },
+)
+logger = logging.getLogger(__name__)
+
+
+logger.debug("Loading jinja2 templates...")
 jinja2_env = jinja2.Environment(
     loader=jinja2.ChoiceLoader(
         [
@@ -58,11 +76,15 @@ templates = Jinja2Templates(env=jinja2_env)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """FastAPI Lifespan."""
-    # Create Connection Pool
+    logger.debug("Connecting to db...")
     await connect_to_db(app)
+    logger.debug("Connected to db.")
+
     yield
-    # Close the Connection Pool
+
+    logger.debug("Closing db connections...")
     await close_db_connection(app)
+    logger.debug("Closed db connection.")
 
 
 app = FastAPI(

--- a/runtimes/eoapi/raster/eoapi/raster/logs.py
+++ b/runtimes/eoapi/raster/eoapi/raster/logs.py
@@ -1,0 +1,30 @@
+from typing import Dict
+import logging
+
+
+def init_logging(debug: bool = False, loggers: Dict[str, str] = {}):
+    logging.config.dictConfig(
+        # https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "std": {
+                    "format": "[%(asctime)s +0000] [%(process)d] [%(levelname)s] %(name)s: %(message)s",
+                }
+            },
+            "handlers": {
+                "stdout": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                    "formatter": "std",
+                }
+            },
+            "loggers": {
+                # Root logger config
+                "": {"handlers": ["stdout"], "level": "DEBUG" if debug else "INFO"},
+                # Customized logger config
+                **loggers,
+            },
+        }
+    )

--- a/runtimes/eoapi/raster/eoapi/raster/logs.py
+++ b/runtimes/eoapi/raster/eoapi/raster/logs.py
@@ -1,9 +1,9 @@
-from typing import Dict
-import logging
+from logging import config
+from typing import Any, Dict
 
 
-def init_logging(debug: bool = False, loggers: Dict[str, str] = {}):
-    logging.config.dictConfig(
+def init_logging(debug: bool = False, loggers: Dict[str, Any] = {}):
+    config.dictConfig(
         # https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
         {
             "version": 1,

--- a/runtimes/eoapi/stac/eoapi/stac/app.py
+++ b/runtimes/eoapi/stac/eoapi/stac/app.py
@@ -34,7 +34,7 @@ from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
 from starlette_cramjam.middleware import CompressionMiddleware
 
-from . import auth, config, extension, logs
+from . import config, extension, logs
 
 try:
     from importlib.resources import files as resources_files  # type: ignore
@@ -65,8 +65,10 @@ extensions_map = {
     "pagination": TokenPaginationExtension(),
     "filter": FilterExtension(client=FiltersClient()),
     "bulk_transactions": BulkTransactionExtension(client=BulkTransactionsClient()),
-    "titiler": extension.TiTilerExtension(
-        titiler_endpoint=api_settings.titiler_endpoint
+    "titiler": (
+        extension.TiTilerExtension(titiler_endpoint=api_settings.titiler_endpoint)
+        if api_settings.titiler_endpoint
+        else None
     ),
 }
 

--- a/runtimes/eoapi/stac/eoapi/stac/logs.py
+++ b/runtimes/eoapi/stac/eoapi/stac/logs.py
@@ -1,0 +1,30 @@
+from typing import Dict
+import logging
+
+
+def init_logging(debug: bool = False, loggers: Dict[str, str] = {}):
+    logging.config.dictConfig(
+        # https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "std": {
+                    "format": "[%(asctime)s +0000] [%(process)d] [%(levelname)s] %(name)s: %(message)s",
+                }
+            },
+            "handlers": {
+                "stdout": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                    "formatter": "std",
+                }
+            },
+            "loggers": {
+                # Root logger config
+                "": {"handlers": ["stdout"], "level": "DEBUG" if debug else "INFO"},
+                # Customized logger config
+                **loggers,
+            },
+        }
+    )

--- a/runtimes/eoapi/stac/eoapi/stac/logs.py
+++ b/runtimes/eoapi/stac/eoapi/stac/logs.py
@@ -1,9 +1,9 @@
-from typing import Dict
-import logging
+from logging import config
+from typing import Any, Dict
 
 
-def init_logging(debug: bool = False, loggers: Dict[str, str] = {}):
-    logging.config.dictConfig(
+def init_logging(debug: bool = False, loggers: Dict[str, Any] = {}):
+    config.dictConfig(
         # https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
         {
             "version": 1,

--- a/runtimes/eoapi/vector/eoapi/vector/app.py
+++ b/runtimes/eoapi/vector/eoapi/vector/app.py
@@ -15,7 +15,8 @@ from tipg.factory import Endpoints as TiPgEndpoints
 from tipg.middleware import CacheControlMiddleware, CatalogUpdateMiddleware
 from tipg.settings import PostgresSettings
 
-from . import __version__ as eoapi_vector_version, config, logs
+from . import __version__ as eoapi_vector_version
+from . import config, logs
 
 try:
     from importlib.resources import files as resources_files  # type: ignore

--- a/runtimes/eoapi/vector/eoapi/vector/app.py
+++ b/runtimes/eoapi/vector/eoapi/vector/app.py
@@ -1,10 +1,9 @@
 """eoapi.vector app."""
 
+import logging
 from contextlib import asynccontextmanager
 
 import jinja2
-from eoapi.vector import __version__ as eoapi_vector_version
-from eoapi.vector.config import ApiSettings
 from fastapi import FastAPI, Request
 from starlette.middleware.cors import CORSMiddleware
 from starlette.templating import Jinja2Templates
@@ -16,6 +15,8 @@ from tipg.factory import Endpoints as TiPgEndpoints
 from tipg.middleware import CacheControlMiddleware, CatalogUpdateMiddleware
 from tipg.settings import PostgresSettings
 
+from . import __version__ as eoapi_vector_version, config, logs
+
 try:
     from importlib.resources import files as resources_files  # type: ignore
 except ImportError:
@@ -25,13 +26,34 @@ except ImportError:
 
 CUSTOM_SQL_DIRECTORY = resources_files(__package__) / "sql"
 
-settings = ApiSettings()
+settings = config.ApiSettings()
 postgres_settings = PostgresSettings()
+
+# Logs
+logs.init_logging(
+    debug=settings.debug,
+    loggers={
+        "botocore.credentials": {
+            "level": "CRITICAL",
+            "propagate": False,
+        },
+        "botocore.utils": {
+            "level": "CRITICAL",
+            "propagate": False,
+        },
+        "rio-tiler": {
+            "level": "ERROR",
+            "propagate": False,
+        },
+    },
+)
+logger = logging.getLogger(__name__)
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """FastAPI Lifespan."""
+    logger.debug("Connecting to db...")
     await connect_to_db(
         app,
         settings=postgres_settings,
@@ -39,6 +61,8 @@ async def lifespan(app: FastAPI):
         schemas=["pgstac", "public"],
         user_sql_files=list(CUSTOM_SQL_DIRECTORY.glob("*.sql")),  # type: ignore
     )
+
+    logger.debug("Registering collection catalog...")
     await register_collection_catalog(
         app,
         # For the Tables' Catalog we only use the `public` schema
@@ -52,6 +76,7 @@ async def lifespan(app: FastAPI):
     yield
 
     # Close the Connection Pool
+    logger.debug("Closing db connections...")
     await close_db_connection(app)
 
 

--- a/runtimes/eoapi/vector/eoapi/vector/logs.py
+++ b/runtimes/eoapi/vector/eoapi/vector/logs.py
@@ -1,0 +1,30 @@
+from typing import Dict
+import logging
+
+
+def init_logging(debug: bool = False, loggers: Dict[str, str] = {}):
+    logging.config.dictConfig(
+        # https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "std": {
+                    "format": "[%(asctime)s +0000] [%(process)d] [%(levelname)s] %(name)s: %(message)s",
+                }
+            },
+            "handlers": {
+                "stdout": {
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                    "formatter": "std",
+                }
+            },
+            "loggers": {
+                # Root logger config
+                "": {"handlers": ["stdout"], "level": "DEBUG" if debug else "INFO"},
+                # Customized logger config
+                **loggers,
+            },
+        }
+    )

--- a/runtimes/eoapi/vector/eoapi/vector/logs.py
+++ b/runtimes/eoapi/vector/eoapi/vector/logs.py
@@ -1,9 +1,9 @@
-from typing import Dict
-import logging
+from logging import config
+from typing import Any, Dict
 
 
-def init_logging(debug: bool = False, loggers: Dict[str, str] = {}):
-    logging.config.dictConfig(
+def init_logging(debug: bool = False, loggers: Dict[str, Any] = {}):
+    config.dictConfig(
         # https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
         {
             "version": 1,


### PR DESCRIPTION
## What I am changing

This PR adds a helper to enable stdout logging on the Python applications.

Additionally, I've refactored the imports to comply with [`PEP-0008`](https://peps.python.org/pep-0008/#imports) conventions:

> Imports should be grouped in the following order:
> 
> 1. Standard library imports.
> 2. Related third party imports.
> 3. Local application/library specific imports.


## How I did it

Add simple `logs.py` helper file.

## How you can test it

Start up apps in debug mode, note debug logs regarding connection to the database. 