### PR TITLE
add csv and geojson-seq output format

### DIFF
--- a/runtimes/eoapi/stac/eoapi/stac/api.py
+++ b/runtimes/eoapi/stac/eoapi/stac/api.py
@@ -157,6 +157,8 @@ class StacApi(app.StacApi):
                     "content": {
                         MimeTypes.geojson.value: {},
                         MimeTypes.html.value: {},
+                        MimeTypes.csv.value: {},
+                        MimeTypes.geojsonseq.value: {},
                     },
                     "model": api.ItemCollection,
                 },
@@ -187,6 +189,8 @@ class StacApi(app.StacApi):
                     "content": {
                         MimeTypes.geojson.value: {},
                         MimeTypes.html.value: {},
+                        MimeTypes.csv.value: {},
+                        MimeTypes.geojsonseq.value: {},
                     },
                     "model": api.ItemCollection,
                 },
@@ -197,5 +201,36 @@ class StacApi(app.StacApi):
             methods=["GET"],
             endpoint=create_async_endpoint(
                 self.client.get_search, self.search_get_request_model
+            ),
+        )
+
+    def register_post_search(self):
+        """Register search endpoint (POST /search).
+
+        Returns:
+            None
+        """
+        self.router.add_api_route(
+            name="Search",
+            path="/search",
+            response_model=api.ItemCollection
+            if self.settings.enable_response_models
+            else None,
+            responses={
+                200: {
+                    "content": {
+                        MimeTypes.geojson.value: {},
+                        MimeTypes.csv.value: {},
+                        MimeTypes.geojsonseq.value: {},
+                    },
+                    "model": api.ItemCollection,
+                },
+            },
+            response_class=GeoJSONResponse,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["POST"],
+            endpoint=create_async_endpoint(
+                self.client.post_search, self.search_post_request_model
             ),
         )

--- a/runtimes/eoapi/stac/eoapi/stac/app.py
+++ b/runtimes/eoapi/stac/eoapi/stac/app.py
@@ -43,6 +43,7 @@ from .api import StacApi
 from .client import FiltersClient, PgSTACClient
 from .config import Settings
 from .extensions import (
+    HTMLorGeoMultiOutputExtension,
     HTMLorGeoOutputExtension,
     HTMLorJSONOutputExtension,
     ItemCollectionFilterExtension,
@@ -84,7 +85,7 @@ search_extensions = [
     FieldsExtension(),
     SearchFilterExtension(client=FiltersClient()),  # type: ignore
     TokenPaginationExtension(),
-    HTMLorGeoOutputExtension(),
+    HTMLorGeoMultiOutputExtension(),
 ]
 
 # collection_search extensions
@@ -111,7 +112,7 @@ itm_col_extensions = [
     FieldsExtension(conformance_classes=[FieldsConformanceClasses.ITEMS]),
     ItemCollectionFilterExtension(client=FiltersClient()),  # type: ignore
     TokenPaginationExtension(),
-    HTMLorGeoOutputExtension(),
+    HTMLorGeoMultiOutputExtension(),
 ]
 
 # Request Models

--- a/runtimes/eoapi/stac/eoapi/stac/client.py
+++ b/runtimes/eoapi/stac/eoapi/stac/client.py
@@ -494,7 +494,7 @@ class PgSTACClient(CoreCrudClient):
         if next_link or prev_link:
             additional_headers["Link"] = ",".join(
                 [
-                    f'{link["href"]}; rel="{link["rel"]}"'
+                    f'<{link["href"]}>; rel="{link["rel"]}"'
                     for link in [next_link, prev_link]
                     if link
                 ]
@@ -638,7 +638,7 @@ class PgSTACClient(CoreCrudClient):
         if next_link or prev_link:
             additional_headers["Link"] = ",".join(
                 [
-                    f'{link["href"]}; rel="{link["rel"]}"'
+                    f'<{link["href"]}>; rel="{link["rel"]}"'
                     for link in [next_link, prev_link]
                     if link
                 ]

--- a/runtimes/eoapi/stac/eoapi/stac/extensions.py
+++ b/runtimes/eoapi/stac/eoapi/stac/extensions.py
@@ -131,6 +131,16 @@ class HTMLorGeoGetRequest(APIRequest):
     ] = attr.ib(default=None)
 
 
+@attr.s
+class HTMLorGeoGetRequestMulti(APIRequest):
+    """HTML, GeoJSON, GeoJSONSeq or CSV output."""
+
+    f: Annotated[
+        Optional[Literal["geojson", "html", "csv", "geojsonseq"]],
+        Query(description="Response MediaType."),
+    ] = attr.ib(default=None)
+
+
 @attr.s(kw_only=True)
 class HTMLorJSONOutputExtension(ApiExtension):
     """TiTiler extension."""
@@ -147,6 +157,17 @@ class HTMLorGeoOutputExtension(ApiExtension):
     """TiTiler extension."""
 
     GET = HTMLorGeoGetRequest
+    POST = None
+
+    def register(self, app: FastAPI) -> None:
+        pass
+
+
+@attr.s(kw_only=True)
+class HTMLorGeoMultiOutputExtension(ApiExtension):
+    """TiTiler extension."""
+
+    GET = HTMLorGeoGetRequestMulti
     POST = None
 
     def register(self, app: FastAPI) -> None:

--- a/runtimes/eoapi/stac/pyproject.toml
+++ b/runtimes/eoapi/stac/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "stac-fastapi.pgstac>=4.0,<4.1",
+    "stac-fastapi.pgstac>=4.0.2,<4.1",
     "jinja2>=2.11.2,<4.0.0",
     "starlette-cramjam>=0.4,<0.5",
     "psycopg_pool",


### PR DESCRIPTION
This PR does:

- adds `csv` and `geojson-seq` outputs to `GET - /items`, `GET - /search` and `POST - /search` 
- refactor `client` to avoid using `super()` method (because the origin method can return JSONResponse directly) 

For `csv` and `geojson-seq` (considered as programatic access) we add the pagination links in the `Headers` following https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Link 👇 

```
curl http://127.0.0.1:8081/search\?limit\=1\&fields\=properties.datetime --header "Accept: text/csv" -v
*   Trying 127.0.0.1:8081...
* Connected to 127.0.0.1 (127.0.0.1) port 8081
> GET /search?limit=1&fields=properties.datetime HTTP/1.1
> Host: 127.0.0.1:8081
> User-Agent: curl/8.4.0
> Accept: text/csv
> 
< HTTP/1.1 200 OK
< date: Sun, 16 Feb 2025 15:49:57 GMT
< server: uvicorn
< content-disposition: attachment;filename=items.csv
< link: <http://127.0.0.1:8081/search?limit=1&fields=properties.datetime&token=next:MAXAR_Nepal_Earthquake_Nov_2023:44_120220012023_10300100F0446700>; rel="next"
< content-type: text/csv; charset=utf-8
< Transfer-Encoding: chunked
< 
itemId,collectionId,datetime
44_120220012023_10300100F0446700,MAXAR_Nepal_Earthquake_Nov_2023,2023-11-09T05:04:10Z
```

Sadly there is no specification for POST request pagination links so we might need to come up with something 🤷 