### PR TITLE
add settings to enable transaction

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,8 @@ services:
       - DB_MAX_CONN_SIZE=1
       # - TITILER_ENDPOINT=raster
       - TITILER_ENDPOINT=http://127.0.0.1:8082
-      # PgSTAC extensions
-      # - EXTENSIONS=["filter", "query", "sort", "fields", "pagination", "titiler", "transaction"]  # defaults
+      # Transtaction Extension
+      # - ENABLE_TRANSACTION=TRUE
       # - CORS_METHODS='GET,POST,PUT,OPTIONS'
     env_file:
       - path: .env

--- a/runtimes/eoapi/stac/eoapi/stac/app.py
+++ b/runtimes/eoapi/stac/eoapi/stac/app.py
@@ -23,13 +23,16 @@ from stac_fastapi.extensions.core import (
     OffsetPaginationExtension,
     SortExtension,
     TokenPaginationExtension,
+    TransactionExtension,
 )
 from stac_fastapi.extensions.core.fields import FieldsConformanceClasses
 from stac_fastapi.extensions.core.free_text import FreeTextConformanceClasses
 from stac_fastapi.extensions.core.query import QueryConformanceClasses
 from stac_fastapi.extensions.core.sort import SortConformanceClasses
+from stac_fastapi.extensions.third_party import BulkTransactionExtension
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
 from stac_fastapi.pgstac.extensions import QueryExtension
+from stac_fastapi.pgstac.transactions import BulkTransactionsClient, TransactionsClient
 from stac_fastapi.pgstac.types.search import PgstacSearch
 from starlette.middleware import Middleware
 from starlette.middleware.cors import CORSMiddleware
@@ -72,6 +75,18 @@ logger = logging.getLogger(__name__)
 # Extensions
 # application extensions
 application_extensions = []
+
+if settings.enable_transaction:
+    application_extensions.append(
+        TransactionExtension(
+            client=TransactionsClient(),
+            settings=settings,
+            response_class=ORJSONResponse,
+        )
+    )
+    application_extensions.append(
+        BulkTransactionExtension(client=BulkTransactionsClient())
+    )
 
 if settings.titiler_endpoint:
     application_extensions.append(

--- a/runtimes/eoapi/stac/eoapi/stac/config.py
+++ b/runtimes/eoapi/stac/eoapi/stac/config.py
@@ -44,6 +44,7 @@ class Settings(config.Settings):
     pgstac_secret_arn: Optional[str] = None
 
     titiler_endpoint: Optional[str] = None
+    enable_transaction: bool = False
 
     debug: bool = False
 


### PR DESCRIPTION
This PR adds a `ENABLE_TRANSACTION` (default to False) settings to add the transaction endpoints

**Warnings** we shouldn't deploy a stack with `ENABLE_TRANSACTION=TRUE` before adding authentification 

cc @danielfdsilva @hrodmn @alukach 