### PR TITLE
Feature: add collection render layers to map in HTML collection view

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,7 @@ services:
       - MOSAIC_CONCURRENCY=1
       - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+      - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
     env_file:
       - path: .env
         required: false

--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -4,6 +4,7 @@ import boto3
 import yaml
 from aws_cdk import (
     App,
+    Duration,
     RemovalPolicy,
     Stack,
     aws_certificatemanager,
@@ -388,10 +389,17 @@ class eoAPIStack(Stack):
                 default_root_object="index.html",
                 error_responses=[
                     aws_cloudfront.ErrorResponse(
+                        http_status=403,
+                        response_http_status=200,
+                        response_page_path="/index.html",
+                        ttl=Duration.seconds(0),
+                    ),
+                    aws_cloudfront.ErrorResponse(
                         http_status=404,
                         response_http_status=200,
                         response_page_path="/index.html",
-                    )
+                        ttl=Duration.seconds(0),
+                    ),
                 ],
                 certificate=aws_certificatemanager.Certificate.from_certificate_arn(
                     self,

--- a/runtimes/eoapi/stac/eoapi/stac/app.py
+++ b/runtimes/eoapi/stac/eoapi/stac/app.py
@@ -212,6 +212,7 @@ api = StacApi(
         title=settings.stac_fastapi_title,
         description=settings.stac_fastapi_description,
         pgstac_search_model=search_post_model,
+        titiler_endpoint=settings.titiler_endpoint,
     ),
     item_get_request_model=item_get_model,
     items_get_request_model=items_get_model,

--- a/runtimes/eoapi/stac/eoapi/stac/app.py
+++ b/runtimes/eoapi/stac/eoapi/stac/app.py
@@ -212,7 +212,6 @@ api = StacApi(
         title=settings.stac_fastapi_title,
         description=settings.stac_fastapi_description,
         pgstac_search_model=search_post_model,
-        titiler_endpoint=settings.titiler_endpoint,
     ),
     item_get_request_model=item_get_model,
     items_get_request_model=items_get_model,

--- a/runtimes/eoapi/stac/eoapi/stac/client.py
+++ b/runtimes/eoapi/stac/eoapi/stac/client.py
@@ -260,7 +260,7 @@ def add_render_links(collection: Collection, titiler_endpoint: str) -> Collectio
                 {
                     "rel": "tilejson",
                     "title": f"{render} tilejson",
-                    "type": MimeTypes.html.value,
+                    "type": MimeTypes.json.value,
                     "href": f"{base_url}/tilejson.json?{query_params}",
                 }
             )

--- a/runtimes/eoapi/stac/eoapi/stac/templates/collection.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/collection.html
@@ -124,7 +124,7 @@
     }
     
     // Add any tilejson links as layers to the map
-    const tileJsonLinks = collection.links.filter(link => link.rel === "tilejson");
+    const tileJsonLinks = collection.links.filter(link => link.rel === "tiles");
     
     const overlayLayers = {};
     
@@ -133,6 +133,7 @@
         fetch(link.href)
           .then(response => response.json())
           .then(tileJson => {
+            console.log(tileJson)
             const tileLayer = L.tileLayer(tileJson.tiles[0], {
               attribution: tileJson.attribution || '',
               minZoom: tileJson.minzoom || 0,

--- a/runtimes/eoapi/stac/eoapi/stac/templates/collection.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/collection.html
@@ -39,7 +39,7 @@
         {% for keyword in response.keywords %}
         <li class="badge badge-secondary">{{ keyword }}</li>
         {% endfor %}
-      </lul>
+      </ul>
     </div>
     {% endif %}
 
@@ -72,10 +72,24 @@
 </div>
 
 {% if response.extent and response.extent.spatial %}
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/2.0.0/Control.FullScreen.css" />
+<script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/2.0.0/Control.FullScreen.min.js"></script>
+
 <script>
   window.addEventListener("load", function() {
     const collection = {{ response|tojson }};
-    var map = L.map('map').setView([0, 0], 1);
+    var map = L.map('map', {
+      fullscreenControl: true,
+      fullscreenControlOptions: {
+        position: 'bottomright',
+        title: 'View Fullscreen',
+        titleCancel: 'Exit Fullscreen',
+        content: '<i class="fa fa-expand"></i>'  // You can customize this icon
+      }
+    }).setView([0, 0], 1);
+    
     var osmLayer = new L.TileLayer(
       'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 18,
@@ -84,6 +98,7 @@
     );
     map.addLayer(osmLayer);
 
+    // Draw the bounding boxes
     for (let i = 0, len = collection.extent.spatial.bbox.length; i < len; i++) {
       const options = i === 0 ? {
         fill: false,
@@ -102,35 +117,29 @@
         [bbox[3], bbox[0]]
       ], options);
 
-
       map.addLayer(bbox_polygon);
       if (i === 0) {
         map.fitBounds(bbox_polygon.getBounds());
       }
     }
-    // Find all TileJSON links
+    
+    // Add any tilejson links as layers to the map
     const tileJsonLinks = collection.links.filter(link => link.rel === "tilejson");
     
-    // Create an object to hold our overlay layers
     const overlayLayers = {};
     
-    // Process each TileJSON link
     if (tileJsonLinks.length > 0) {
       tileJsonLinks.forEach((link, index) => {
-        // Fetch the TileJSON data
         fetch(link.href)
           .then(response => response.json())
           .then(tileJson => {
-            // Create a tile layer using the TileJSON data
             const tileLayer = L.tileLayer(tileJson.tiles[0], {
               attribution: tileJson.attribution || '',
               minZoom: tileJson.minzoom || 0,
               maxZoom: tileJson.maxzoom || 18
             });
             
-            // Add a title for the layer
-            const layerName = link.title || `TileJSON Layer ${index + 1}`;
-            overlayLayers[layerName] = tileLayer;
+            overlayLayers[layerName] = link.title || `TileJSON Layer ${index + 1}`;
             
             // Add the first layer to the map by default
             if (index === 0) {
@@ -153,7 +162,17 @@
           });
       });
     }
-
+    
+    // Handle fullscreen change event to resize map
+    map.on('fullscreenchange', function() {
+      if (map.isFullscreen()) {
+        console.log('Entered fullscreen');
+      } else {
+        console.log('Exited fullscreen');
+      }
+      // Make sure the map fills the container after fullscreen changes
+      map.invalidateSize();
+    });
   });
 </script>
 {% endif %}

--- a/runtimes/eoapi/stac/eoapi/stac/templates/collection.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/collection.html
@@ -139,7 +139,8 @@
               maxZoom: tileJson.maxzoom || 18
             });
             
-            overlayLayers[layerName] = link.title || `TileJSON Layer ${index + 1}`;
+            const layerName = link.title || `TileJSON Layer ${index + 1}`;
+            overlayLayers[layerName] = tileLayer;
             
             // Add the first layer to the map by default
             if (index === 0) {

--- a/runtimes/eoapi/stac/eoapi/stac/templates/collection.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/collection.html
@@ -76,12 +76,13 @@
   window.addEventListener("load", function() {
     const collection = {{ response|tojson }};
     var map = L.map('map').setView([0, 0], 1);
-    map.addLayer(new L.TileLayer(
+    var osmLayer = new L.TileLayer(
       'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 18,
         attribution: 'Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap contributors</a>'
       }
-    ));
+    );
+    map.addLayer(osmLayer);
 
     for (let i = 0, len = collection.extent.spatial.bbox.length; i < len; i++) {
       const options = i === 0 ? {
@@ -107,6 +108,52 @@
         map.fitBounds(bbox_polygon.getBounds());
       }
     }
+    // Find all TileJSON links
+    const tileJsonLinks = collection.links.filter(link => link.rel === "tilejson");
+    
+    // Create an object to hold our overlay layers
+    const overlayLayers = {};
+    
+    // Process each TileJSON link
+    if (tileJsonLinks.length > 0) {
+      tileJsonLinks.forEach((link, index) => {
+        // Fetch the TileJSON data
+        fetch(link.href)
+          .then(response => response.json())
+          .then(tileJson => {
+            // Create a tile layer using the TileJSON data
+            const tileLayer = L.tileLayer(tileJson.tiles[0], {
+              attribution: tileJson.attribution || '',
+              minZoom: tileJson.minzoom || 0,
+              maxZoom: tileJson.maxzoom || 18
+            });
+            
+            // Add a title for the layer
+            const layerName = link.title || `TileJSON Layer ${index + 1}`;
+            overlayLayers[layerName] = tileLayer;
+            
+            // Add the first layer to the map by default
+            if (index === 0) {
+              tileLayer.addTo(map);
+            }
+            
+            // Add layer control after all layers are processed
+            if (index === tileJsonLinks.length - 1) {
+              // Define the base layers
+              const baseLayers = {
+                "OpenStreetMap": osmLayer
+              };
+              
+              // Add the layer control to the map
+              L.control.layers(baseLayers, overlayLayers).addTo(map);
+            }
+          })
+          .catch(error => {
+            console.error("Error loading TileJSON:", error);
+          });
+      });
+    }
+
   });
 </script>
 {% endif %}


### PR DESCRIPTION
This does two things:
* adds links to the `/WebMercatorQuad/tilejson.json` and `WebMercatorQuad/tilejson.json` endpoints to the `/collections/{collection_id}` STAC json response for any available `renders` extension entries
  *  this is nice for because STAC browser will display the links for easy access to the visualizations
  * I think it is a little messy because `map` and `tilejson` are not true rel types :shrug: 
* loads any tilejson layers into the map view in the collection HTML response in the STAC API
  * and adds full screen button 

![image](https://github.com/user-attachments/assets/da45727d-ba87-48e0-9946-820c6de2950b)
