### PR TITLE
handle limit-offset in templates

### DIFF
--- a/runtimes/eoapi/stac/eoapi/stac/client.py
+++ b/runtimes/eoapi/stac/eoapi/stac/client.py
@@ -1,7 +1,6 @@
 """eoapi-devseed: Custom pgstac client."""
 
 import csv
-import math
 import re
 from typing import (
     Any,
@@ -363,21 +362,11 @@ class PgSTACClient(CoreCrudClient):
             )
 
         if output_type == MimeTypes.html:
-            offset = int(request.query_params.get("offset") or 0)
-            limit = int(request.query_params.get("limit") or 10)
-
-            current_page = 1
-            if limit > 0:
-                current_page = math.ceil((offset + limit) / limit)
-
             return create_html_response(
                 request,
                 collections,
                 template_name="collections",
                 title="Collections list",
-                current_page=current_page,
-                limit=limit,
-                offset=offset,
             )
 
         return collections
@@ -529,7 +518,6 @@ class PgSTACClient(CoreCrudClient):
                 item_collection,
                 template_name="items",
                 title=f"{collection_id} items",
-                limit=limit,
             )
 
         elif output_type == MimeTypes.csv:

--- a/runtimes/eoapi/stac/eoapi/stac/templates/collections.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/collections.html
@@ -24,7 +24,7 @@
 {% else %}
 <div class="d-flex flex-row align-items-center mb-4 flex-wrap">
   <div class="mr-3">
-    Showing {{ offset + 1 }} - {{ offset + response.numberReturned }} of {{ response.numberMatched }} collections
+    Showing {{ template.params.get("offset", 0)|int + 1 }} - {{ template.params.get("offset", 0)|int + response.numberReturned }} of {{ response.numberMatched }} collections
   </div>
 
   <form id="search-form" class="d-flex flex-wrap flex-grow-1" style="gap: 8px">
@@ -43,10 +43,10 @@
     <div class="d-flex">
       <label for="limit" class="mr-1 small">Page size:</label>
       <select class="form-control form-control-sm" id="limit" aria-label="Select page size" style="width: 70px">
-        <option value="10" {% if limit == 10 %}selected{% endif %}>10</option>
-        <option value="25" {% if limit == 25 %}selected{% endif %}>25</option>
-        <option value="50" {% if limit == 50 %}selected{% endif %}>50</option>
-        <option value="100" {% if limit == 100 %}selected{% endif %}>100</option>
+        <option value="10" {% if template.params.get("limit", 10)|int == 10 %}selected{% endif %}>10</option>
+        <option value="25" {% if template.params.get("limit", 10)|int == 25 %}selected{% endif %}>25</option>
+        <option value="50" {% if template.params.get("limit", 10)|int == 50 %}selected{% endif %}>50</option>
+        <option value="100" {% if template.params.get("limit", 10)|int == 100 %}selected{% endif %}>100</option>
       </select>
     </div>
 

--- a/runtimes/eoapi/stac/eoapi/stac/templates/collections.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/collections.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% if params %}
+  {% set urlq = url + '?' + params + '&' %}
+  {% else %}
+  {% set urlq = url + '?' %}
+{% endif %}
+
 {% block content %}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">

--- a/runtimes/eoapi/stac/eoapi/stac/templates/items.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/items.html
@@ -36,10 +36,10 @@
     <div class="d-flex">
       <label for="limit">Page size: </label>
       <select class="form-control form-control-sm ml-1" id="limit" aria-label="Select page size"> <!-- TODO: dynamically populate the values based on oga_max_limit -->
-        <option value="10" {% if limit == 10 %}selected{% endif %}>10</option>
-        <option value="25" {% if limit == 25 %}selected{% endif %}>25</option>
-        <option value="50" {% if limit == 50 %}selected{% endif %}>50</option>
-        <option value="100" {% if limit == 100 %}selected{% endif %}>100</option>
+        <option value="10" {% if template.params.get("limit", 10)|int == 10 %}selected{% endif %}>10</option>
+        <option value="25" {% if template.params.get("limit", 10)|int == 25 %}selected{% endif %}>25</option>
+        <option value="50" {% if template.params.get("limit", 10)|int == 50 %}selected{% endif %}>50</option>
+        <option value="100" {% if template.params.get("limit", 10)|int == 100 %}selected{% endif %}>100</option>
       </select>
     </div>
     {% if response.links|length > 0 %}


### PR DESCRIPTION
@oliverroick I realized that we could access the `query-parameters` directly in the template, instead of having to change the python code. 

FYI: I'm working on adding the HTML response into a Middleware, so I need to have templates that do not expect custom values provided, but just the regular stac-fastapi response 