### PR TITLE
Update item page

### DIFF
--- a/runtimes/eoapi/stac/eoapi/stac/templates/item.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/item.html
@@ -28,12 +28,53 @@
     <h2>Properties</h2>
     <ul>
       <li><strong>ID:</strong> {{ response.id }}</li>
-      {% for key, value in response.properties.items() %}
+      {% for key, value in response.properties | dictsort %}
       <li><strong>{{ key }}:</strong> {{ value }}</li>
       {% endfor %}
     </ul>
 
-    <h2>Links</h2>
+    <h2 class="mt-5">Assets</h2>
+    <ul class="list-unstyled">
+      {% for key, asset in response.assets.items() %}
+      <li class="mb-4">
+        <p class="small text-monospace text-muted mb-0">{{ key }}</p>
+        {% if asset.title %}<p class="mb-0"><b>{{ asset.title }}</b></p>{% endif %}
+        {% if asset.type %}<p class="mb-0">{{ asset.type }}</p>{% endif %}
+        {% if asset.description %}<p class="mb-0">{{ asset.description }}</p>{% endif %}
+        <ul class="list-inline">
+          <li class="list-inline-item"><a href="{{ asset.href }}">Asset link</a></li>
+          {% if asset.alternate %}
+          {% for alternate_key, alternate_link in asset.alternate.items() %}
+          <li class="list-inline-item"><a href="{{ alternate_link.href }}">{{ alternate_link.title or alternate_key }}</a></li>
+          {% endfor %}
+          {% endif %}
+        </ul>
+        {% if asset.roles and asset.roles|length > 0 %}
+        <ul class="list-inline">
+          {% for role in asset.roles %}
+          <li class="list-inline-item badge badge-light">{{ role }}</li>
+          {% endfor %}
+        </ul>
+        {% endif %}
+
+        <details class="mt-2">
+          <summary>Asset Properties</summary>
+          {% for asset_key, asset_opt in asset | dictsort if asset_key not in ["title", "type", "href", "roles", "alternate"] %}
+          <div class="row mt-2 small">
+            <div class="col-3">{{ asset_key }}</div>
+            <div class="col-9">
+              <pre>{{ asset_opt | tojson(2) }}</pre>
+            </div>
+          </div>
+          {% else %}
+          No additional properties for this asset.
+          {% endfor %}
+        </details>
+      </li>
+      {% endfor %}
+    </ul>
+
+    <h2 class="mt-5">Links</h2>
     <ul>
       {% for link in response.links %}
       <li><a href="{{ link.href }}">{{ link.title or link.rel }}</a></li>

--- a/runtimes/eoapi/stac/eoapi/stac/templates/item.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/item.html
@@ -1,10 +1,12 @@
-{% include "header.html" %}
+{% extends "base.html" %}
+
 {% if params %}
   {% set urlq = url + '?' + params + '&' %}
   {% else %}
   {% set urlq = url + '?' %}
 {% endif %}
 
+{% block content %}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb bg-light">
     {% for crumb in crumbs %}
@@ -158,5 +160,4 @@
   }
 
 </script>
-
-{% include "footer.html" %}
+{% endblock %}

--- a/runtimes/eoapi/stac/eoapi/stac/templates/item.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/item.html
@@ -26,10 +26,20 @@
 <div class="row">
   <div class="col-md-7">
     <h2>Properties</h2>
-    <ul>
-      <li><strong>ID:</strong> {{ response.id }}</li>
+    <ul class="list-unstyled">
+      <li class="row small mb-1">
+        <div class="col-3 font-weight-bold">ID</div>
+        <div class="col-9">
+          <pre class="mb-0">{{ response.id }}</pre>
+        </div>
+      </li>
       {% for key, value in response.properties | dictsort %}
-      <li><strong>{{ key }}:</strong> {{ value }}</li>
+      <li class="row small mb-1">
+        <div class="col-3 font-weight-bold">{{ key }}</div>
+        <div class="col-9">
+          <pre class="mb-0">{{ value | tojson(2) | trim('"') }}</pre>
+        </div>
+      </li>
       {% endfor %}
     </ul>
 
@@ -60,10 +70,10 @@
         <details class="mt-2">
           <summary>Asset Properties</summary>
           {% for asset_key, asset_opt in asset | dictsort if asset_key not in ["title", "type", "href", "roles", "alternate"] %}
-          <div class="row mt-2 small">
-            <div class="col-3">{{ asset_key }}</div>
+          <div class="row mb-1 small">
+            <div class="col-3 font-weight-bold">{{ asset_key }}</div>
             <div class="col-9">
-              <pre>{{ asset_opt | tojson(2) }}</pre>
+              <pre class="mb-0">{{ asset_opt | tojson(2) }}</pre>
             </div>
           </div>
           {% else %}

--- a/runtimes/eoapi/stac/eoapi/stac/templates/item.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/item.html
@@ -49,8 +49,10 @@
     <ul class="list-unstyled">
       {% for key, asset in response.assets.items() %}
       <li class="mb-4">
-        <p class="small text-monospace text-muted mb-0">{{ key }}</p>
-        {% if asset.title %}<p class="mb-0"><b>{{ asset.title }}</b></p>{% endif %}
+        <p class="mb-0 font-weight-bold ">
+          <span class="text-muted text-monospace">{{ key }}</span>
+          {% if asset.title and not key == asset.title %} &bull; {{ asset.title }}{% endif %}
+        </p>
         {% if asset.type %}<p class="mb-0">{{ asset.type }}</p>{% endif %}
         {% if asset.description %}<p class="mb-0">{{ asset.description }}</p>{% endif %}
         <ul class="list-inline">

--- a/runtimes/eoapi/stac/eoapi/stac/templates/item.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/item.html
@@ -32,6 +32,13 @@
       <li><strong>{{ key }}:</strong> {{ value }}</li>
       {% endfor %}
     </ul>
+
+    <h2>Links</h2>
+    <ul>
+      {% for link in response.links %}
+      <li><a href="{{ link.href }}">{{ link.title or link.rel }}</a></li>
+      {% endfor %}
+    </ul>
   </div>
   <div class="col-md-5">
     <div id="map" class="rounded" style="width:100%;height:400px;">Loading...</div>

--- a/runtimes/eoapi/stac/eoapi/stac/templates/item.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/item.html
@@ -18,10 +18,13 @@
   </ol>
 </nav>
 
-<h1>Collection Item: {{ response.id }}</h1>
+<h1 class="my-4">
+  <span class="d-block text-uppercase text-muted h6 mb-0">Collection Item:</span>
+  {{ response.id }}
+</h1>
 
 <div class="row">
-  <div class="col-sm">
+  <div class="col-md-7">
     <h2>Properties</h2>
     <ul>
       <li><strong>ID:</strong> {{ response.id }}</li>
@@ -30,7 +33,7 @@
       {% endfor %}
     </ul>
   </div>
-  <div class="col-sm">
+  <div class="col-md-5">
     <div id="map" class="rounded" style="width:100%;height:400px;">Loading...</div>
   </div>
 </div>

--- a/runtimes/eoapi/stac/eoapi/stac/templates/item.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/item.html
@@ -71,7 +71,7 @@
 
         <details class="mt-2">
           <summary>Asset Properties</summary>
-          {% for asset_key, asset_opt in asset | dictsort if asset_key not in ["title", "type", "href", "roles", "alternate"] %}
+          {% for asset_key, asset_opt in asset | dictsort if asset_key not in ["title", "type", "description", "href", "roles", "alternate"] %}
           <div class="row mb-1 small">
             <div class="col-3 font-weight-bold">{{ asset_key }}</div>
             <div class="col-9">

--- a/runtimes/eoapi/stac/eoapi/stac/templates/item.html
+++ b/runtimes/eoapi/stac/eoapi/stac/templates/item.html
@@ -92,7 +92,7 @@
     </ul>
   </div>
   <div class="col-md-5">
-    <div id="map" class="rounded" style="width:100%;height:400px;">Loading...</div>
+    <div id="map" class="rounded" style="width:100%; height:calc(-6rem + 100vh); position: sticky; top: 5rem;">Loading...</div>
   </div>
 </div>
 


### PR DESCRIPTION
- Updates page header to match other pages
- Adds links (ref #43).
- Adds items assets (ref #43). The asset display is the same as the one on the collection page. Additional properties are shown in a disclosure, otherwise the page would be very long and convoluted. 
- Updates the styling of item properties using columns and pretty print for property values, which makes complex JSON object more readable. (I'll update other pages to match this once the change is approved here)
- Update map positioning, it now stays in place when you scroll. (I'll update other pages to match this once the change is approved here)
